### PR TITLE
Added construction coverage tests and updated constructors

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -60,8 +60,12 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+    - name: Test
+      run: dotnet test --no-restore --verbosity normal
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,6 +49,12 @@ jobs:
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
+        
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0'
+        include-prerelease: True
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -64,8 +64,6 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --configuration Release --no-restore
-    - name: Test
-      run: dotnet test --no-restore --verbosity normal
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -49,7 +51,7 @@ jobs:
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
-        
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "6.0.100",
-    "rollForward": "latestFeature"
+    "rollForward": "latestMajor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100",
+    "version": "6.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/samples/Samples.csproj
+++ b/samples/Samples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/samples/Samples.csproj
+++ b/samples/Samples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/samples/Samples.csproj
+++ b/samples/Samples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net60</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/samples/Samples.csproj
+++ b/samples/Samples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net60</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Liminality/LiminalEngine.cs
+++ b/src/Liminality/LiminalEngine.cs
@@ -9,7 +9,7 @@ namespace PSIBR.Liminality
     public sealed class LiminalEngine
     {
         private readonly IServiceProvider _serviceProvider;
-        public LiminalEngine(IServiceProvider serviceProvider)
+        public LiminalEngine(IServiceProvider serviceProvider!!)
         {
             _serviceProvider = serviceProvider;
         }

--- a/src/Liminality/Liminality.csproj
+++ b/src/Liminality/Liminality.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
 	<LangVersion>preview</LangVersion>
     <PackageId>PSIBR.Liminality</PackageId>
     <Title>Transition library by a transfem so you know it's good</Title>

--- a/src/Liminality/Liminality.csproj
+++ b/src/Liminality/Liminality.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net60</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
 	<LangVersion>preview</LangVersion>
     <PackageId>PSIBR.Liminality</PackageId>
     <Title>Transition library by a transfem so you know it's good</Title>

--- a/src/Liminality/Liminality.csproj
+++ b/src/Liminality/Liminality.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net60</TargetFramework>
 	<LangVersion>preview</LangVersion>
     <PackageId>PSIBR.Liminality</PackageId>
     <Title>Transition library by a transfem so you know it's good</Title>

--- a/src/Liminality/Liminality.csproj
+++ b/src/Liminality/Liminality.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+	<LangVersion>preview</LangVersion>
     <PackageId>PSIBR.Liminality</PackageId>
     <Title>Transition library by a transfem so you know it's good</Title>
     <Description>

--- a/src/Liminality/ServiceCollectionExtensions.cs
+++ b/src/Liminality/ServiceCollectionExtensions.cs
@@ -6,7 +6,7 @@ namespace PSIBR.Liminality
 {
     public static class ServiceCollectionExtensions
     {
-        public static void AddLiminality(this IServiceCollection services)
+        public static void AddLiminality(this IServiceCollection services!!)
         {
             services.AddScoped<LiminalEngine>();
         }

--- a/src/Liminality/SignalContext.cs
+++ b/src/Liminality/SignalContext.cs
@@ -3,7 +3,7 @@ namespace PSIBR.Liminality
     public class SignalContext<TStateMachine>
     where TStateMachine : StateMachine<TStateMachine>
     {
-        public SignalContext(TStateMachine self, object startingState, object newState)
+        public SignalContext(TStateMachine self!!, object startingState, object newState)
         {
             Self = self;
             StartingState = startingState;

--- a/src/Liminality/SignalResult.cs
+++ b/src/Liminality/SignalResult.cs
@@ -9,7 +9,7 @@ namespace PSIBR.Liminality
     public class AggregateSignalResult 
         : IReadOnlyList<ISignalResult>
     {
-        public AggregateSignalResult(IReadOnlyList<ISignalResult> resultStack)
+        public AggregateSignalResult(IReadOnlyList<ISignalResult> resultStack!!)
         {
             if(resultStack is null) throw new ArgumentNullException(nameof(resultStack));
             if(resultStack.Count == 0) throw new ArgumentException("Cannot be empty", nameof(resultStack));

--- a/src/Liminality/StateMachine.cs
+++ b/src/Liminality/StateMachine.cs
@@ -8,7 +8,7 @@ namespace PSIBR.Liminality
     where TStateMachine : StateMachine<TStateMachine>
     {
         private readonly LiminalEngine _engine;
-        protected StateMachine(LiminalEngine engine, StateMachineDefinition<TStateMachine> definition)
+        protected StateMachine(LiminalEngine engine!!, StateMachineDefinition<TStateMachine> definition!!)
         {
             _engine = engine;
             Definition = definition;

--- a/src/Liminality/StateMachineBuilder.cs
+++ b/src/Liminality/StateMachineBuilder.cs
@@ -15,7 +15,7 @@ namespace PSIBR.Liminality
         {
             private readonly StateMachineStateMap _stateMachineDefintion;
 
-            public StateBuilder(StateMachineStateMap stateMachineDefinition)
+            public StateBuilder(StateMachineStateMap stateMachineDefinition!!)
             {
                 _stateMachineDefintion = stateMachineDefinition;
             }
@@ -42,7 +42,7 @@ namespace PSIBR.Liminality
         {
             private readonly StateBuilder _stateBuilder;
 
-            public ForStateContext(StateBuilder stateBuilder)
+            public ForStateContext(StateBuilder stateBuilder!!)
             {
                 _stateBuilder = stateBuilder;
             }
@@ -58,7 +58,7 @@ namespace PSIBR.Liminality
         {
             private readonly StateBuilder _stateBuilder;
 
-            public OnContext(StateBuilder stateBuilder)
+            public OnContext(StateBuilder stateBuilder!!)
             {
                 _stateBuilder = stateBuilder;
             }

--- a/src/Liminality/StateMachineDefinition.cs
+++ b/src/Liminality/StateMachineDefinition.cs
@@ -7,7 +7,7 @@ namespace PSIBR.Liminality
     public class StateMachineDefinition<TStateMachine>
     where TStateMachine : StateMachine<TStateMachine>
     {
-        public StateMachineDefinition(StateMachineStateMap map)
+        public StateMachineDefinition(StateMachineStateMap map!!)
         {
             StateMap = map;
         }

--- a/src/Liminality/StateMachineStateMap.cs
+++ b/src/Liminality/StateMachineStateMap.cs
@@ -5,7 +5,7 @@ namespace PSIBR.Liminality
 {
     public class StateMachineStateMap : Dictionary<StateMachineStateMap.Input, StateMachineStateMap.Transition>
     {
-        public StateMachineStateMap(Type initialState)
+        public StateMachineStateMap(Type initialState!!)
         {
             InitialState = initialState;
         }
@@ -17,7 +17,7 @@ namespace PSIBR.Liminality
             public Type CurrentStateType;
             public Type SignalType;
 
-            public Input(Type stateType, Type signalType)
+            public Input(Type stateType!!, Type signalType!!)
             {
                 CurrentStateType = stateType;
                 SignalType = signalType;
@@ -34,7 +34,7 @@ namespace PSIBR.Liminality
         {
             public Type NewStateType;
 
-            public Transition(Type newState)
+            public Transition(Type newState!!)
             {
                 NewStateType = newState;
             }

--- a/test/Liminality.Tests/Fixtures/NoOpLiminalEngineFixture.cs
+++ b/test/Liminality.Tests/Fixtures/NoOpLiminalEngineFixture.cs
@@ -1,0 +1,41 @@
+﻿using Lamar;
+using PSIBR.Liminality.Tests;
+using System;
+
+namespace PSIBR.Liminality.Fixtures
+{
+    /// <summary>
+    /// NoOpLiminalEngineFixture provides a set of instances for
+    /// state machine components that can be used to validate
+    /// the API surfaces, such as ensuring constructors and
+    /// functions enforce based contract requirements
+    /// </summary>
+    public class NoOpLiminalEngineFixture : IDisposable
+    {
+        public class TestState { }
+
+        public NoOpLiminalEngineFixture()
+        {
+            Container = new Container(_ => { });
+            LiminalEngine = new LiminalEngine(Container);
+            StateMachineStateMap = new StateMachineStateMap(typeof(object));
+            StateMachineDefinition = new StateMachineDefinition<BasicStateMachine>(StateMachineStateMap);
+            StateMachine = new BasicStateMachine(LiminalEngine, StateMachineDefinition);
+            Signal = new object();
+            State = new TestState();
+        }
+
+        public Container Container { get; private set; }
+        public LiminalEngine LiminalEngine { get; private set; }
+        public BasicStateMachine StateMachine { get; private set; }
+        public StateMachineDefinition<BasicStateMachine> StateMachineDefinition { get; private set; }
+        public StateMachineStateMap StateMachineStateMap { get; private set; }
+        public object Signal { get; private set; }
+        public TestState State { get; private set; }
+
+        public void Dispose()
+        {
+            Container.Dispose();
+        }
+    }
+}

--- a/test/Liminality.Tests/LiminalEngineTests.cs
+++ b/test/Liminality.Tests/LiminalEngineTests.cs
@@ -1,0 +1,82 @@
+﻿using Lamar;
+using PSIBR.Liminality.Fixtures;
+using PSIBR.Liminality.Tests;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PSIBR.Liminality
+{
+    public class LiminalEngineTests : IClassFixture<NoOpLiminalEngineFixture>
+    {
+        public LiminalEngineTests(NoOpLiminalEngineFixture fixture)
+        {
+            Fixture = fixture;
+        }
+
+        protected readonly NoOpLiminalEngineFixture Fixture;
+
+        [Trait("Category", "Construction")]
+        [Fact(DisplayName = "Constructing LiminalEngine with valid args succeeds")]
+        public void LiminalEngine_Valid_Construction_Succeeds()
+        {
+            //Arrange
+            var container = new Container(_ => { });
+
+            //Act
+            var liminalEngine = new LiminalEngine(container);
+
+            //Assert
+            //No assertion: Construction without exception is a pass
+        }
+
+        [Trait("Category", "Construction")]
+        [Fact(DisplayName = "Constructing LiminalEngine with null args throws")]
+        public void LiminalEngine_Invalid_Construction_Throws()
+        {
+            //Arrange
+            IServiceProvider? services = default(IServiceProvider);
+
+            //Act
+            //Assert
+            //CS8604 is intentionally disabled to get rid of compiler warnings
+            //so that we can validate good handling of this condition for
+            //consumers that don't have nullable enabled
+#pragma warning disable CS8604 // Possible null reference argument.
+            Assert.Throws<ArgumentNullException>(() => new LiminalEngine(services));
+#pragma warning restore CS8604 // Possible null reference argument.
+        }
+
+        [Trait("Category", "Signals")]
+        [Fact(DisplayName = "LiminalEngine SignalAsync with valid signal succeeds")]
+        public async Task LiminalEngine_SignalAsync_Valid_Signal_Succeeds()
+        {
+            await Fixture.LiminalEngine.SignalAsync(
+                Fixture.StateMachine,
+                Fixture.Signal,
+                _ => new ValueTask<object>(Fixture.Signal),
+                (state, cancellationToken) => { state = Fixture.State; return new ValueTask(); }
+            );
+        }
+
+        [Trait("Category", "Signals")]
+        [Fact(DisplayName = "LiminalEngine SignalAsync with null signal succeeds")]
+        public async Task LiminalEngine_SignalAsync_Invalid_Signal_Fails()
+        {
+            object? signal = null;
+#pragma warning disable CS8604 // Possible null reference argument.
+            //CS8604 is intentionally disabled to get rid of compiler warnings
+            //so that we can validate good handling of this condition for
+            //consumers that don't have nullable enabled
+
+            await Fixture.LiminalEngine.SignalAsync<BasicStateMachine, object>(
+                Fixture.StateMachine,
+                signal,
+                _ => new ValueTask<object>(Fixture.Signal),
+                (state, cancellationToken) => { state = Fixture.State; return new ValueTask(); }
+            );
+
+#pragma warning restore CS8604 // Possible null reference argument.
+        }
+    }
+}

--- a/test/Liminality.Tests/Liminality.Tests.csproj
+++ b/test/Liminality.Tests/Liminality.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net60</TargetFramework>
     <RootNamespace>PSIBR.Liminality</RootNamespace>
     <nullable>enable</nullable>
     <IsPackable>false</IsPackable>

--- a/test/Liminality.Tests/Liminality.Tests.csproj
+++ b/test/Liminality.Tests/Liminality.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net60</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <RootNamespace>PSIBR.Liminality</RootNamespace>
     <nullable>enable</nullable>
     <IsPackable>false</IsPackable>

--- a/test/Liminality.Tests/Liminality.Tests.csproj
+++ b/test/Liminality.Tests/Liminality.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>PSIBR.Liminality</RootNamespace>
     <nullable>enable</nullable>
-    
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Liminality.Tests/Liminality.Tests.csproj
+++ b/test/Liminality.Tests/Liminality.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <RootNamespace>PSIBR.Liminality</RootNamespace>
     <nullable>enable</nullable>
     <IsPackable>false</IsPackable>

--- a/test/Liminality.Tests/StateMachineTests.cs
+++ b/test/Liminality.Tests/StateMachineTests.cs
@@ -1,0 +1,67 @@
+﻿using Lamar;
+using PSIBR.Liminality.Fixtures;
+using PSIBR.Liminality.Tests;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PSIBR.Liminality
+{
+    public class StateMachineTests : IClassFixture<NoOpLiminalEngineFixture>
+    {
+        public StateMachineTests(NoOpLiminalEngineFixture fixture)
+        {
+            Fixture = fixture;
+        }
+
+        protected readonly NoOpLiminalEngineFixture Fixture;
+
+        [Trait("Category", "Construction")]
+        [Fact(DisplayName = "Constructing LiminalEngine with valid args succeeds")]
+        public void StateMachine_Valid_Construction_Succeeds()
+        {
+            //Arrange
+            var container = new Container(_ => { });
+
+            //Act
+            //Though using BasicStateMachine, the goal is to validate
+            //the base class construction
+            var stateMachine = new BasicStateMachine(Fixture.LiminalEngine, Fixture.StateMachineDefinition);
+
+            //Assert
+            //No assertion: Construction without exception is a pass
+        }
+
+        [Trait("Category", "Construction")]
+        [Fact(DisplayName = "Constructing LiminalEngine with null args throws")]
+        public void StateMachine_Invalid_Construction_Throws()
+        {
+            //Arrange
+            LiminalEngine? liminalEngine = default(LiminalEngine);
+            StateMachineDefinition<BasicStateMachine>? stateMachineDefinition = default(StateMachineDefinition<BasicStateMachine>);
+
+            //Act
+            //Assert
+            //CS8604 is intentionally disabled to get rid of compiler warnings
+            //so that we can validate good handling of this condition for
+            //consumers that don't have nullable enabled
+#pragma warning disable CS8604 // Possible null reference argument.
+            Assert.Throws<ArgumentNullException>(() => new BasicStateMachine(liminalEngine, stateMachineDefinition));
+#pragma warning restore CS8604 // Possible null reference argument.
+        }
+
+        [Trait("Category", "Signals")]
+        [Fact(DisplayName = "LiminalEngine SignalAsync with valid signal succeeds")]
+        public async Task StateMachine_SignalAsync_Valid_Signal_Succeeds()
+        {
+            var stateMachine = new BasicStateMachine(Fixture.LiminalEngine, Fixture.StateMachineDefinition);
+            await stateMachine.SignalAsync(
+                Fixture.Signal,
+                default
+            );
+        }
+    }
+}


### PR DESCRIPTION
I opened this as draft since I turned on preview and used a few other lang features that we may not want since I didn't talk to you first.

- Added a noop text fixture for validating API surface calls
- Updated to .NET 6.0 and enabled langversion=preview
- Updated global.json to point to SDK 6.0.100